### PR TITLE
Update prerequisites in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ If you run into any problems, or have a suggestion for a new feature, please fir
 
 ### Prerequisites
 
-* Flutter >= 3.13.5
-* Dart >= 3.1.2
+* Flutter >= 3.19.0
+* Dart >= 3.3.0
 * Java >= 17
 
 A full tutorial on how to get started with Flutter is available at https://docs.flutter.dev/get-started/install


### PR DESCRIPTION
The Flutter minimum version is derived from sdk (Dart) minimum version, as described on this page: https://docs.flutter.dev/release/archive